### PR TITLE
fixing bug with cumulative descriptors

### DIFF
--- a/lib/ZernikeDescriptor.cpp
+++ b/lib/ZernikeDescriptor.cpp
@@ -287,11 +287,11 @@ void ZernikeDescriptor<T,TIn>::ComputeInvariants ()
     {
         //invariants_[n].resize (n/2 + 1);
 
-        T sum = (T)0;
         int l0 = n % 2, li = 0;
 
         for (int l = n % 2; l<=n; ++li, l+=2)
         {
+            T sum = (T)0;
             for (int m=-l; m<=l; ++m)
             {
                 ComplexT moment = zm_.GetMoment (n, l, m);


### PR DESCRIPTION
Please see the details here (section Reference Methods): https://journals.plos.org/ploscompbiol/article?id=10.1371/journal.pcbi.1007970
Also compare with our implementation: https://github.com/biocryst/biozernike/blob/17db94ed567d683eabfd3171d127d5bdc2add741/src/main/java/org/rcsb/biozernike/InvariantNorm.java#L395-L414